### PR TITLE
fix: add missing overload for pipe with 10 args

### DIFF
--- a/fns.ts
+++ b/fns.ts
@@ -117,6 +117,18 @@ export type PipeFn = {
     gh: (g: G) => H,
     hi: (h: H) => I,
   ): I;
+  <A, B, C, D, E, F, G, H, I, J>(
+    a: A,
+    ab: (a: A) => B,
+    bc: (b: B) => C,
+    cd: (c: C) => D,
+    de: (d: D) => E,
+    ef: (e: E) => F,
+    fg: (f: F) => G,
+    gh: (g: G) => H,
+    hi: (h: H) => I,
+    ij: (i: I) => J,
+  ): J;
   <A, B, C, D, E, F, G, H, I, J, K>(
     a: A,
     ab: (a: A) => B,


### PR DESCRIPTION
PipeFn was missing an overload for 10 arguments, when there are overloads for more than 10 arguments.